### PR TITLE
GitHub workflow to verify new commits.

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -23,10 +23,11 @@ permissions:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         python-version: ['3.9', '3.x']
 
     steps:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -36,7 +36,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-        cache: 'poetry'
+        # cache: 'poetry'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -36,7 +36,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-        # cache: 'poetry'
+        cache: poetry
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.x']
+        python-version: ['3.9', '3.x']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -32,17 +32,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Install poetry
+      run: pipx install poetry
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
         cache: poetry
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pipx
-        pipx install poetry
-        poetry install
+      run: poetry install
     - name: Sort imports
       run: poetry run poe sort
     - name: Lint Code

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.9', 'pypy3.9', '3.13', 'pypy3.13', '3.x']
+        python-version: ['3.9', 'pypy3.10', 'pypy3.11', '3.11', '3.x']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.9', 'pypy3.10', 'pypy3.11', '3.11', '3.x']
+        python-version: ['3.9', '3.x']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -35,6 +35,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'poetry'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -40,7 +40,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install poetry
+        pip install pipx
+        pipx install poetry
         poetry install
     - name: Sort imports
       run: poetry run sort

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.9, 3.10, 3.11, '3.x']
+        python-version: ['3.9', '3.10', '3.11', '3.x']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,54 @@
+# This workflow
+# - installs Python dependencies,
+# - sorts imports,
+# - lints code,
+# - formats code,
+# - runs tests,
+# - checks Python type hints, and
+# - verifies the build.
+#
+# These steps are run for each supported Python version, plus the latest version.
+
+name: Python application
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: [3.9, 3.10, 3.11, '3.x']
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install poetry
+        poetry install
+    - name: Sort imports
+      run: poetry run sort
+    - name: Lint Code
+      run: poetry run lint
+    - name: Format Code
+      run: poetry run format
+    - name: Run Tests
+      run: poetry run test
+    - name: Type Check
+      run: poetry run type
+    - name: Verify
+      run: poetry run checkall

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.9', 'pypy3.9', '3.x', 'pypy3.x']
+        python-version: ['3.9', 'pypy3.9', '3.13', 'pypy3.13', '3.x']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.9', '3.x']
+        python-version: ['3.9', 'pypy3.9', '3.x', 'pypy3.x']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -44,14 +44,14 @@ jobs:
         pipx install poetry
         poetry install
     - name: Sort imports
-      run: poetry run sort
+      run: poetry run poe sort
     - name: Lint Code
-      run: poetry run lint
+      run: poetry run poe lint
     - name: Format Code
-      run: poetry run format
+      run: poetry run poe format
     - name: Run Tests
-      run: poetry run test
+      run: poetry run poe test
     - name: Type Check
-      run: poetry run type
+      run: poetry run poe type
     - name: Verify
-      run: poetry run checkall
+      run: poetry run poe checkall

--- a/beetsplug/redacted/__init__.py
+++ b/beetsplug/redacted/__init__.py
@@ -3,6 +3,7 @@
 
 import time
 from pkgutil import extend_path
+from typing import Union
 
 import frozendict
 from beets.dbcore import types as dbtypes  # type: ignore[import-untyped]
@@ -72,7 +73,7 @@ class RedactedPlugin(BeetsPlugin):
         if self._client and self.config["auto"].get(bool):
             self.import_stages = [self.import_stage]
 
-    def _get_client(self, http_client: HTTPClient) -> RedactedClient | None:
+    def _get_client(self, http_client: HTTPClient) -> Union[RedactedClient, None]:
         """Get or create the RedactedClient instance."""
         api_key = self.config["api_key"].get()
         if not api_key:

--- a/beetsplug/redacted/http.py
+++ b/beetsplug/redacted/http.py
@@ -4,6 +4,7 @@ import logging
 import os
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
+from typing import Union
 
 import requests
 from backoff import expo, full_jitter, on_exception
@@ -131,7 +132,7 @@ class CachedRequestsClient(RequestsClient):
 
     def _get_cached_response(
         self, params: dict[str, str], headers: dict[str, str]
-    ) -> requests.Response | None:
+    ) -> Union[requests.Response, None]:
         """Get a cached response if available and not expired.
 
         Args:

--- a/beetsplug/redacted/matching.py
+++ b/beetsplug/redacted/matching.py
@@ -92,7 +92,10 @@ def extract_album_fields(album: Album) -> Matchable:
 
 
 def score_match(
-    item1: Matchable, item2: Matchable, log: logging.Logger, weights: Union[dict[str, float], None] = None
+    item1: Matchable,
+    item2: Matchable,
+    log: logging.Logger,
+    weights: Union[dict[str, float], None] = None,
 ) -> MatchResult:
     """Score the match between two items.
 

--- a/beetsplug/redacted/matching.py
+++ b/beetsplug/redacted/matching.py
@@ -2,6 +2,7 @@
 
 import logging
 from difflib import SequenceMatcher
+from typing import Union
 
 from beets.library import Album  # type: ignore[import-untyped]
 from pydantic.dataclasses import dataclass
@@ -16,9 +17,9 @@ class Matchable:
     title: str = ""
 
     # Optional fields
-    year: int | None = None
-    media: str | None = None
-    format: str | None = None
+    year: Union[int, None] = None
+    media: Union[str, None] = None
+    format: Union[str, None] = None
 
 
 @dataclass
@@ -44,7 +45,7 @@ def string_similarity(a: str, b: str) -> float:
     return SequenceMatcher(None, a.lower(), b.lower()).ratio()
 
 
-def year_similarity(year1: int | None, year2: int | None) -> float:
+def year_similarity(year1: Union[int, None], year2: Union[int, None]) -> float:
     """Calculate year similarity.
 
     Args:
@@ -91,7 +92,7 @@ def extract_album_fields(album: Album) -> Matchable:
 
 
 def score_match(
-    item1: Matchable, item2: Matchable, log: logging.Logger, weights: dict[str, float] | None = None
+    item1: Matchable, item2: Matchable, log: logging.Logger, weights: Union[dict[str, float], None] = None
 ) -> MatchResult:
     """Score the match between two items.
 

--- a/beetsplug/redacted/search.py
+++ b/beetsplug/redacted/search.py
@@ -294,9 +294,9 @@ def beets_fields_from_artist_torrent_groups(
             continue
 
         source_cls = from_meta.get_source_cls()
-        source_obj: Union[RedArtistResponseResults, RedArtistTorrentGroup, RedArtistTorrent, None] = (
-            None
-        )
+        source_obj: Union[
+            RedArtistResponseResults, RedArtistTorrentGroup, RedArtistTorrent, None
+        ] = None
         if source_cls == RedArtistResponseResults:
             source_obj = artist
         elif source_cls == RedArtistTorrentGroup:

--- a/beetsplug/redacted/search.py
+++ b/beetsplug/redacted/search.py
@@ -3,6 +3,7 @@
 import dataclasses
 import itertools
 import logging
+from typing import Union
 
 from beets.library import Album  # type: ignore[import-untyped]
 from pydantic import ValidationError
@@ -23,7 +24,7 @@ from beetsplug.redacted.types import (
 from beetsplug.redacted.utils.search_utils import normalize_query
 
 
-def torrent_group_matchable(group: RedSearchResult) -> Matchable | None:
+def torrent_group_matchable(group: RedSearchResult) -> Union[Matchable, None]:
     """Extract normalized fields from a Redacted torrent group.
 
     Args:
@@ -38,8 +39,8 @@ def torrent_group_matchable(group: RedSearchResult) -> Matchable | None:
 
 
 def artist_torrent_group_matchable(
-    group: RedArtistTorrentGroup, artist_name: str | None
-) -> Matchable | None:
+    group: RedArtistTorrentGroup, artist_name: Union[str, None]
+) -> Union[Matchable, None]:
     """Extract normalized fields from a Redacted artist torrent group.
 
     Args:
@@ -56,7 +57,7 @@ def artist_torrent_group_matchable(
 
 def match_album(
     album: Album, results: RedSearchResponse, log: logging.Logger, min_score: float
-) -> tuple[RedSearchResult | None, float]:
+) -> tuple[Union[RedSearchResult, None], float]:
     """Check if an album exists in search results.
 
     The matching algorithm uses a weighted scoring system:
@@ -90,7 +91,7 @@ def match_album(
         return None, 0.0
 
     # Find the best match among all groups
-    best_match: RedSearchResult | None = None
+    best_match: Union[RedSearchResult, None] = None
     best_match_score: float = 0.0
     weights = {"artist": 0.5, "title": 0.4, "year": 0.1}
 
@@ -147,7 +148,7 @@ def match_album(
 
 def match_artist_album(
     album: Album, artist_response: RedArtistResponse, log: logging.Logger, min_score: float
-) -> tuple[RedArtistTorrentGroup, RedArtistTorrent] | None:
+) -> tuple[Union[RedArtistTorrentGroup, None], Union[RedArtistTorrent, None]]:
     """Match an album against artist's torrent groups.
 
     Args:
@@ -168,11 +169,11 @@ def match_artist_album(
 
     if not torrent_groups:
         log.debug("Artist {:s} has no torrent groups", artist_data.name)
-        return None
+        return None, None
 
     # Find the best match among all artist's torrent groups
-    best_group: RedArtistTorrentGroup | None = None
-    best_torrent: RedArtistTorrent | None = None
+    best_group: Union[RedArtistTorrentGroup, None] = None
+    best_torrent: Union[RedArtistTorrent, None] = None
     best_match_score: float = 0.0
 
     # Title and year weights are more important when artist is already known
@@ -218,7 +219,7 @@ def match_artist_album(
             artist_data.name,
             [(g.groupId, g.groupName, g.groupYear) for g in torrent_groups if g.groupName],
         )
-        return None
+        return None, None
 
     if best_match_score < min_score:
         log.debug(
@@ -229,7 +230,7 @@ def match_artist_album(
             best_match_score,
             min_score,
         )
-        return None
+        return None, None
 
     log.debug(
         "Best match for {0} from artist's groups: {1} (score: {2:.2f})",
@@ -241,7 +242,7 @@ def match_artist_album(
     return best_group, best_torrent
 
 
-def get_artist_id_from_red_group(group: RedSearchResult, log: logging.Logger) -> int | None:
+def get_artist_id_from_red_group(group: RedSearchResult, log: logging.Logger) -> Union[int, None]:
     """Extract artist ID from a torrent.
 
     Args:
@@ -274,7 +275,7 @@ def beets_fields_from_artist_torrent_groups(
     group: RedArtistTorrentGroup,
     torrent: RedArtistTorrent,
     log: logging.Logger,
-) -> BeetsRedFields | None:
+) -> Union[BeetsRedFields, None]:
     """Extract fields from an artist group and torrent match.
 
     Args:
@@ -293,7 +294,7 @@ def beets_fields_from_artist_torrent_groups(
             continue
 
         source_cls = from_meta.get_source_cls()
-        source_obj: RedArtistResponseResults | RedArtistTorrentGroup | RedArtistTorrent | None = (
+        source_obj: Union[RedArtistResponseResults, RedArtistTorrentGroup, RedArtistTorrent, None] = (
             None
         )
         if source_cls == RedArtistResponseResults:
@@ -337,7 +338,7 @@ def beets_fields_from_artist_torrent_groups(
 
 def search(
     album: Album, client: RedactedClient, log: logging.Logger, min_score: float
-) -> BeetsRedFields | None:
+) -> Union[BeetsRedFields, None]:
     """Search for Redacted torrents matching an album using a two-step process.
 
     First searches for torrents using the browse API, then looks up artist details
@@ -421,10 +422,8 @@ def search(
         return None
 
     # Find a match for the album in the artist's discography
-    artist_match = match_artist_album(album, artist_data, log, min_score)
-    if artist_match:
-        artist_group, artist_torrent = artist_match
-
+    artist_group, artist_torrent = match_artist_album(album, artist_data, log, min_score)
+    if artist_group and artist_torrent:
         # Extract album update fields from artist group (album) and torrent match
         return beets_fields_from_artist_torrent_groups(
             artist_data.response, artist_group, artist_torrent, log

--- a/beetsplug/redacted/types.py
+++ b/beetsplug/redacted/types.py
@@ -177,13 +177,13 @@ Response format:
 # ruff: noqa: N815
 
 import dataclasses
-from enum import StrEnum
+from enum import Enum
 from typing import Generic, Literal, TypeVar, Union
 
 from pydantic.dataclasses import dataclass
 
 
-class RedAction(StrEnum):
+class RedAction(Enum):
     """Valid actions for the Redacted API."""
 
     BROWSE = "browse"

--- a/beetsplug/redacted/types.py
+++ b/beetsplug/redacted/types.py
@@ -178,7 +178,7 @@ Response format:
 
 import dataclasses
 from enum import StrEnum
-from typing import Generic, Literal, TypeVar
+from typing import Generic, Literal, TypeVar, Union
 
 from pydantic.dataclasses import dataclass
 
@@ -210,32 +210,32 @@ class RedSearchTorrent:
     """
 
     torrentId: int
-    editionId: int | None = None
-    artists: list[RedArtist] | None = None
-    remastered: bool | None = None
-    remasterYear: int | None = None
-    remasterCatalogueNumber: str | None = None
-    remasterTitle: str | None = None
-    media: str | None = None
-    encoding: str | None = None
-    format: str | None = None
-    hasLog: bool | None = None
-    logScore: int | None = None
-    hasCue: bool | None = None
-    scene: bool | None = None
-    vanityHouse: bool | None = None
-    fileCount: int | None = None
-    time: str | None = None
-    size: int | None = None
-    snatches: int | None = None
-    seeders: int | None = None
-    leechers: int | None = None
-    isFreeleech: bool | None = None
-    isNeutralLeech: bool | None = None
-    isFreeload: bool | None = None
-    isPersonalFreeleech: bool | None = None
-    trumpable: bool | None = None
-    canUseToken: bool | None = None
+    editionId: Union[int, None] = None
+    artists: Union[list[RedArtist], None] = None
+    remastered: Union[bool, None] = None
+    remasterYear: Union[int, None] = None
+    remasterCatalogueNumber: Union[str, None] = None
+    remasterTitle: Union[str, None] = None
+    media: Union[str, None] = None
+    encoding: Union[str, None] = None
+    format: Union[str, None] = None
+    hasLog: Union[bool, None] = None
+    logScore: Union[int, None] = None
+    hasCue: Union[bool, None] = None
+    scene: Union[bool, None] = None
+    vanityHouse: Union[bool, None] = None
+    fileCount: Union[int, None] = None
+    time: Union[str, None] = None
+    size: Union[int, None] = None
+    snatches: Union[int, None] = None
+    seeders: Union[int, None] = None
+    leechers: Union[int, None] = None
+    isFreeleech: Union[bool, None] = None
+    isNeutralLeech: Union[bool, None] = None
+    isFreeload: Union[bool, None] = None
+    isPersonalFreeleech: Union[bool, None] = None
+    trumpable: Union[bool, None] = None
+    canUseToken: Union[bool, None] = None
 
 
 @dataclass
@@ -247,20 +247,20 @@ class RedSearchResult:
     database.
     """
 
-    groupId: int | None = None
-    torrents: list[RedSearchTorrent] | None = None
-    groupName: str | None = None
-    artist: str | None = None
-    tags: list[str] | None = None
-    bookmarked: bool | None = None
-    vanityHouse: bool | None = None
-    groupYear: int | None = None
-    releaseType: str | None = None
-    groupTime: int | None = None
-    maxSize: int | None = None
-    totalSnatched: int | None = None
-    totalSeeders: int | None = None
-    totalLeechers: int | None = None
+    groupId: Union[int, None] = None
+    torrents: Union[list[RedSearchTorrent], None] = None
+    groupName: Union[str, None] = None
+    artist: Union[str, None] = None
+    tags: Union[list[str], None] = None
+    bookmarked: Union[bool, None] = None
+    vanityHouse: Union[bool, None] = None
+    groupYear: Union[int, None] = None
+    releaseType: Union[str, None] = None
+    groupTime: Union[int, None] = None
+    maxSize: Union[int, None] = None
+    totalSnatched: Union[int, None] = None
+    totalSeeders: Union[int, None] = None
+    totalLeechers: Union[int, None] = None
 
 
 @dataclass
@@ -323,29 +323,29 @@ class RedArtistTorrent:
     - Different field availability and naming conventions
     """
 
-    id: int | None = None
-    groupId: int | None = None
-    media: str | None = None  # Media, e.g. "Vinyl", "CD", "Web"
-    format: str | None = None  # Format, e.g. "FLAC", "MP3"
-    encoding: str | None = None  # Encoding, e.g. "24bit Lossless", "VBR", "CBR"
-    remasterYear: int | None = None  # Remaster year. 0 indicates no remaster or no value.
-    remastered: bool | None = None
-    remasterTitle: str | None = None
-    remasterRecordLabel: str | None = None
-    scene: bool | None = None
-    hasLog: bool | None = None
-    hasCue: bool | None = None
-    logScore: int | None = None
-    fileCount: int | None = None  # Number of files in the torrent. May include non-audio files.
-    freeTorrent: bool | None = None
-    isNeutralleech: bool | None = None
-    isFreeload: bool | None = None
-    size: int | None = None  # Size of the torrent in bytes.
-    leechers: int | None = None
-    seeders: int | None = None
-    snatched: int | None = None
-    time: str | None = None  # Time string, e.g. "2009-06-06 19:04:22"
-    hasFile: int | None = None  # Unclear what this is.
+    id: Union[int, None] = None
+    groupId: Union[int, None] = None
+    media: Union[str, None] = None  # Media, e.g. "Vinyl", "CD", "Web"
+    format: Union[str, None] = None  # Format, e.g. "FLAC", "MP3"
+    encoding: Union[str, None] = None  # Encoding, e.g. "24bit Lossless", "VBR", "CBR"
+    remasterYear: Union[int, None] = None  # Remaster year. 0 indicates no remaster or no value.
+    remastered: Union[bool, None] = None
+    remasterTitle: Union[str, None] = None
+    remasterRecordLabel: Union[str, None] = None
+    scene: Union[bool, None] = None
+    hasLog: Union[bool, None] = None
+    hasCue: Union[bool, None] = None
+    logScore: Union[int, None] = None
+    fileCount: Union[int, None] = None  # Number of files in the torrent. May include non-audio files.
+    freeTorrent: Union[bool, None] = None
+    isNeutralleech: Union[bool, None] = None
+    isFreeload: Union[bool, None] = None
+    size: Union[int, None] = None  # Size of the torrent in bytes.
+    leechers: Union[int, None] = None
+    seeders: Union[int, None] = None
+    snatched: Union[int, None] = None
+    time: Union[str, None] = None  # Time string, e.g. "2009-06-06 19:04:22"
+    hasFile: Union[int, None] = None  # Unclear what this is.
 
 
 @dataclass
@@ -361,47 +361,47 @@ class RedArtistTorrentGroup:
     - The artist is implied by the parent artist response
     """
 
-    groupId: int | None = None
-    groupName: str | None = None
-    groupYear: int | None = None
-    groupRecordLabel: str | None = None
-    groupCatalogueNumber: str | None = None
-    tags: list[str] | None = None
-    releaseType: int | None = None
-    groupVanityHouse: bool | None = None
-    hasBookmarked: bool | None = None
-    torrent: list[RedArtistTorrent] | None = None
+    groupId: Union[int, None] = None
+    groupName: Union[str, None] = None
+    groupYear: Union[int, None] = None
+    groupRecordLabel: Union[str, None] = None
+    groupCatalogueNumber: Union[str, None] = None
+    tags: Union[list[str], None] = None
+    releaseType: Union[int, None] = None
+    groupVanityHouse: Union[bool, None] = None
+    hasBookmarked: Union[bool, None] = None
+    torrent: Union[list[RedArtistTorrent], None] = None
 
 
 @dataclass
 class RedArtistRequest:
     """Type for a request in an artist result."""
 
-    requestId: int | None = None
-    categoryId: int | None = None
-    title: str | None = None
-    year: int | None = None
-    timeAdded: str | None = None
-    votes: int | None = None
-    bounty: int | None = None
+    requestId: Union[int, None] = None
+    categoryId: Union[int, None] = None
+    title: Union[str, None] = None
+    year: Union[int, None] = None
+    timeAdded: Union[str, None] = None
+    votes: Union[int, None] = None
+    bounty: Union[int, None] = None
 
 
 @dataclass
 class RedArtistResponseResults:
     """Type for the artist response data."""
 
-    id: int | None = None
-    name: str | None = None
-    notificationsEnabled: bool | None = None
-    hasBookmarked: bool | None = None
-    image: str | None = None
-    body: str | None = None
-    vanityHouse: bool | None = None
-    tags: list[RedArtistTag] | None = None
-    similarArtists: list[dict] | None = None
-    statistics: RedArtistStatistics | None = None
-    torrentgroup: list[RedArtistTorrentGroup] | None = None
-    requests: list[RedArtistRequest] | None = None
+    id: Union[int, None] = None
+    name: Union[str, None] = None
+    notificationsEnabled: Union[bool, None] = None
+    hasBookmarked: Union[bool, None] = None
+    image: Union[str, None] = None
+    body: Union[str, None] = None
+    vanityHouse: Union[bool, None] = None
+    tags: Union[list[RedArtistTag], None] = None
+    similarArtists: Union[list[dict], None] = None
+    statistics: Union[RedArtistStatistics, None] = None
+    torrentgroup: Union[list[RedArtistTorrentGroup], None] = None
+    requests: Union[list[RedArtistRequest], None] = None
 
 
 @dataclass
@@ -411,7 +411,7 @@ class RedArtistResponse(RedSuccessResponse):
     response: RedArtistResponseResults
 
 
-RedactedAPIResponse = RedSearchResponse | RedArtistResponse | RedFailureResponse
+RedactedAPIResponse = Union[RedSearchResponse, RedArtistResponse, RedFailureResponse]
 
 # Field metadata for the Beets database
 
@@ -441,7 +441,7 @@ class RedBeetsFieldMapping(Generic[SourceT, ValueT]):
         """Get the value type from the type parameters at runtime."""
         return self.value_type
 
-    def get_value(self, obj: SourceT) -> ValueT | None:
+    def get_value(self, obj: SourceT) -> Union[ValueT, None]:
         """Get the value of the source attribute from the object."""
         if not isinstance(obj, self.get_source_cls()):
             raise TypeError(f"Expected {self.get_source_cls().__name__}, got {type(obj).__name__}")
@@ -469,105 +469,105 @@ class BeetsRedFields:
     """Fields to update on a Beets album relating to Redacted torrents."""
 
     # The last time the redacted fields were modified, in seconds since the epoch
-    red_mtime: float | None = dataclasses.field(default=None)
+    red_mtime: Union[float, None] = dataclasses.field(default=None)
 
     # ID fields
-    red_artistid: int | None = dataclasses.field(
+    red_artistid: Union[int, None] = dataclasses.field(
         default=None, metadata={"from": RBF[AR, int](AR, "id", int), "required": True}
     )
-    red_groupid: int | None = dataclasses.field(
+    red_groupid: Union[int, None] = dataclasses.field(
         default=None, metadata={"from": RBF[GR, int](GR, "groupId", int), "required": True}
     )
-    red_torrentid: int | None = dataclasses.field(
+    red_torrentid: Union[int, None] = dataclasses.field(
         default=None, metadata={"from": RBF[TR, int](TR, "id", int), "required": True}
     )
 
     # Artist fields, from RedArtistResponse
-    red_artist: str | None = dataclasses.field(
+    red_artist: Union[str, None] = dataclasses.field(
         default=None, metadata={"from": RBF[AR, str](AR, "name", str)}
     )
-    red_image: str | None = dataclasses.field(
+    red_image: Union[str, None] = dataclasses.field(
         default=None, metadata={"from": RBF[AR, str](AR, "image", str)}
     )
 
     # Group fields, from RedArtistTorrentGroup
-    red_groupname: str | None = dataclasses.field(
+    red_groupname: Union[str, None] = dataclasses.field(
         default=None, metadata={"from": RBF[GR, str](GR, "groupName", str)}
     )
-    red_groupyear: int | None = dataclasses.field(
+    red_groupyear: Union[int, None] = dataclasses.field(
         default=None, metadata={"from": RBF[GR, int](GR, "groupYear", int)}
     )
-    red_grouprecordlabel: str | None = dataclasses.field(
+    red_grouprecordlabel: Union[str, None] = dataclasses.field(
         default=None, metadata={"from": RBF[GR, str](GR, "groupRecordLabel", str)}
     )
-    red_groupcataloguenumber: str | None = dataclasses.field(
+    red_groupcataloguenumber: Union[str, None] = dataclasses.field(
         default=None, metadata={"from": RBF[GR, str](GR, "groupCatalogueNumber", str)}
     )
-    red_groupreleasetype: int | None = dataclasses.field(
+    red_groupreleasetype: Union[int, None] = dataclasses.field(
         default=None, metadata={"from": RBF[GR, int](GR, "releaseType", int)}
     )
 
     # Torrent fields, from RedArtistTorrent
-    red_media: str | None = dataclasses.field(
+    red_media: Union[str, None] = dataclasses.field(
         default=None, metadata={"from": RBF[TR, str](TR, "media", str)}
     )
-    red_format: str | None = dataclasses.field(
+    red_format: Union[str, None] = dataclasses.field(
         default=None, metadata={"from": RBF[TR, str](TR, "format", str)}
     )
-    red_encoding: str | None = dataclasses.field(
+    red_encoding: Union[str, None] = dataclasses.field(
         default=None, metadata={"from": RBF[TR, str](TR, "encoding", str)}
     )
-    red_remastered: bool | None = dataclasses.field(
+    red_remastered: Union[bool, None] = dataclasses.field(
         default=None, metadata={"from": RBF[TR, bool](TR, "remastered", bool)}
     )
-    red_remasteryear: int | None = dataclasses.field(
+    red_remasteryear: Union[int, None] = dataclasses.field(
         default=None, metadata={"from": RBF[TR, int](TR, "remasterYear", int)}
     )
-    red_remastertitle: str | None = dataclasses.field(
+    red_remastertitle: Union[str, None] = dataclasses.field(
         default=None, metadata={"from": RBF[TR, str](TR, "remasterTitle", str)}
     )
-    red_remasterrecordlabel: str | None = dataclasses.field(
+    red_remasterrecordlabel: Union[str, None] = dataclasses.field(
         default=None, metadata={"from": RBF[TR, str](TR, "remasterRecordLabel", str)}
     )
-    red_scene: bool | None = dataclasses.field(
+    red_scene: Union[bool, None] = dataclasses.field(
         default=None, metadata={"from": RBF[TR, bool](TR, "scene", bool)}
     )
-    red_haslog: bool | None = dataclasses.field(
+    red_haslog: Union[bool, None] = dataclasses.field(
         default=None, metadata={"from": RBF[TR, bool](TR, "hasLog", bool)}
     )
-    red_logscore: int | None = dataclasses.field(
+    red_logscore: Union[int, None] = dataclasses.field(
         default=None, metadata={"from": RBF[TR, int](TR, "logScore", int)}
     )
-    red_hascue: bool | None = dataclasses.field(
+    red_hascue: Union[bool, None] = dataclasses.field(
         default=None, metadata={"from": RBF[TR, bool](TR, "hasCue", bool)}
     )
-    red_filecount: int | None = dataclasses.field(
+    red_filecount: Union[int, None] = dataclasses.field(
         default=None, metadata={"from": RBF[TR, int](TR, "fileCount", int)}
     )
-    red_freetorrent: bool | None = dataclasses.field(
+    red_freetorrent: Union[bool, None] = dataclasses.field(
         default=None, metadata={"from": RBF[TR, bool](TR, "freeTorrent", bool)}
     )
-    red_isneutralleech: bool | None = dataclasses.field(
+    red_isneutralleech: Union[bool, None] = dataclasses.field(
         default=None, metadata={"from": RBF[TR, bool](TR, "isNeutralleech", bool)}
     )
-    red_isfreeload: bool | None = dataclasses.field(
+    red_isfreeload: Union[bool, None] = dataclasses.field(
         default=None, metadata={"from": RBF[TR, bool](TR, "isFreeload", bool)}
     )
-    red_size: int | None = dataclasses.field(
+    red_size: Union[int, None] = dataclasses.field(
         default=None, metadata={"from": RBF[TR, int](TR, "size", int)}
     )
-    red_leechers: int | None = dataclasses.field(
+    red_leechers: Union[int, None] = dataclasses.field(
         default=None, metadata={"from": RBF[TR, int](TR, "leechers", int)}
     )
-    red_seeders: int | None = dataclasses.field(
+    red_seeders: Union[int, None] = dataclasses.field(
         default=None, metadata={"from": RBF[TR, int](TR, "seeders", int)}
     )
-    red_snatched: int | None = dataclasses.field(
+    red_snatched: Union[int, None] = dataclasses.field(
         default=None, metadata={"from": RBF[TR, int](TR, "snatched", int)}
     )
-    red_time: str | None = dataclasses.field(
+    red_time: Union[str, None] = dataclasses.field(
         default=None, metadata={"from": RBF[TR, str](TR, "time", str)}
     )
-    red_hasfile: int | None = dataclasses.field(
+    red_hasfile: Union[int, None] = dataclasses.field(
         default=None, metadata={"from": RBF[TR, int](TR, "hasFile", int)}
     )

--- a/beetsplug/redacted/types.py
+++ b/beetsplug/redacted/types.py
@@ -336,7 +336,9 @@ class RedArtistTorrent:
     hasLog: Union[bool, None] = None
     hasCue: Union[bool, None] = None
     logScore: Union[int, None] = None
-    fileCount: Union[int, None] = None  # Number of files in the torrent. May include non-audio files.
+    fileCount: Union[int, None] = (
+        None  # Number of files in the torrent. May include non-audio files.
+    )
     freeTorrent: Union[bool, None] = None
     isNeutralleech: Union[bool, None] = None
     isFreeload: Union[bool, None] = None

--- a/beetsplug/redacted/utils/search_utils.py
+++ b/beetsplug/redacted/utils/search_utils.py
@@ -1,8 +1,9 @@
 import logging
 import re
+from typing import Union
 
 
-def normalize_query(artist: str | list[str], album: str, log: logging.Logger) -> str | None:
+def normalize_query(artist: Union[str, list[str]], album: str, log: logging.Logger) -> Union[str, None]:
     """Normalize a query string for searching.
 
     Args:

--- a/beetsplug/redacted/utils/search_utils.py
+++ b/beetsplug/redacted/utils/search_utils.py
@@ -3,7 +3,9 @@ import re
 from typing import Union
 
 
-def normalize_query(artist: Union[str, list[str]], album: str, log: logging.Logger) -> Union[str, None]:
+def normalize_query(
+    artist: Union[str, list[str]], album: str, log: logging.Logger
+) -> Union[str, None]:
     """Normalize a query string for searching.
 
     Args:

--- a/beetsplug/redacted/utils/test_utils.py
+++ b/beetsplug/redacted/utils/test_utils.py
@@ -161,7 +161,7 @@ class FakeLibrary:
         self._albums[album.id] = album
         return album
 
-    def albums(self, query: str | None = None) -> Sequence["FakeAlbum"]:
+    def albums(self, query: Union[str, None] = None) -> Sequence["FakeAlbum"]:
         """Get albums from the library.
 
         Args:
@@ -601,7 +601,7 @@ class FakeCommandOpts:
     def __init__(
         self,
         min_score: float = 0.75,
-        query: str | None = None,
+        query: Union[str, None] = None,
         pretend: bool = False,
         force: bool = False,
     ) -> None:
@@ -622,7 +622,7 @@ class FakeCommandOpts:
 class FakeConfigValue:
     """Fake configuration value for testing."""
 
-    def __init__(self, value: float | str) -> None:
+    def __init__(self, value: Union[float, str]) -> None:
         """Initialize fake config value.
 
         Args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "A Redacted plugin for Beets."
 readme = "README.md"
 license = "MIT"
-authors = ["Judas Iscariot <judas@noreply.com"]
+authors = ["Judas Iscariot <judas@noreply.com>"]
 homepage = "https://github.com/judas-red/beets-redacted"
 repository = "https://github.com/judas-red/beets-redacted.git"
 packages = [{ include = "beetsplug", from = "." }]

--- a/tests/beetsplug/redacted/test_init.py
+++ b/tests/beetsplug/redacted/test_init.py
@@ -1,6 +1,7 @@
 """Tests for the Redacted import functionality."""
 
 import time
+from typing import Union
 from unittest.mock import patch
 
 import pytest
@@ -19,7 +20,7 @@ from beetsplug.redacted.utils.test_utils import (
 class FakeImportTask:
     """Mock import task for testing."""
 
-    def __init__(self, album: FakeAlbum | None = None, is_album: bool = True) -> None:
+    def __init__(self, album: Union[FakeAlbum, None] = None, is_album: bool = True) -> None:
         """Initialize fake import task.
 
         Args:

--- a/tests/beetsplug/redacted/test_matching.py
+++ b/tests/beetsplug/redacted/test_matching.py
@@ -1,6 +1,6 @@
 """Tests for matching.py functionality."""
 
-from typing import Any
+from typing import Any, Union
 
 import pytest
 
@@ -61,7 +61,7 @@ def test_string_similarity(str1: str, str2: str, expected_range: tuple[float, fl
         (None, None, 1.0),
     ],
 )
-def test_year_similarity(year1: int | None, year2: int | None, expected: float) -> None:
+def test_year_similarity(year1: Union[int, None], year2: Union[int, None], expected: float) -> None:
     """Test year_similarity function with various year combinations."""
     assert year_similarity(year1, year2) == expected
 
@@ -169,7 +169,7 @@ def test_score_match(
     item1: Matchable,
     item2: Matchable,
     expected_scores: dict[str, tuple[float, float]],
-    weights: dict[str, float] | None,
+    weights: Union[dict[str, float], None],
 ) -> None:
     """Test score_match function with various match scenarios."""
     result = score_match(item1, item2, log, weights)

--- a/tests/beetsplug/redacted/test_search.py
+++ b/tests/beetsplug/redacted/test_search.py
@@ -694,7 +694,10 @@ def test_artist_torrent_group_matchable(group_name: str, expected_result: bool) 
     ],
 )
 def test_match_artist_album_edge_cases(
-    log: FakeLogger, album: FakeAlbum, group_config: dict, expected: Union[tuple[RedArtistTorrentGroup, RedArtistTorrent], None]
+    log: FakeLogger,
+    album: FakeAlbum,
+    group_config: dict,
+    expected: Union[tuple[RedArtistTorrentGroup, RedArtistTorrent], None],
 ) -> None:
     """Test match_artist_album with parameterized edge cases."""
     response = RedArtistResponse(

--- a/tests/beetsplug/redacted/test_search.py
+++ b/tests/beetsplug/redacted/test_search.py
@@ -2,6 +2,7 @@
 
 import dataclasses
 import itertools
+from typing import Union
 
 import pytest
 
@@ -182,7 +183,7 @@ def _make_test_group(
     artist: str = TEST_ARTIST_NAME,
     name: str = TEST_ALBUM_NAME,
     year: int = TEST_ALBUM_YEAR,
-    torrent: RedSearchTorrent | None = None,
+    torrent: Union[RedSearchTorrent, None] = None,
 ) -> RedSearchResult:
     """Create a test group for testing.
 
@@ -247,7 +248,7 @@ def _setup_artist_response(
     client: FakeRedactedClient,
     artist_id: int = TEST_ARTIST_ID,
     artist_name: str = TEST_ARTIST_NAME,
-    torrent_groups: list[RedArtistTorrentGroup] | None = None,
+    torrent_groups: Union[list[RedArtistTorrentGroup], None] = None,
 ) -> None:
     """Set up artist response for the client.
 
@@ -647,7 +648,7 @@ def test_artist_torrent_group_matchable(group_name: str, expected_result: bool) 
 @pytest.mark.parametrize(
     "group_config, expected",
     [
-        pytest.param({"torrentgroup": []}, None, id="no_torrent_groups"),
+        pytest.param({"torrentgroup": []}, (None, None), id="no_torrent_groups"),
         pytest.param(
             {
                 "torrentgroup": [
@@ -659,7 +660,7 @@ def test_artist_torrent_group_matchable(group_name: str, expected_result: bool) 
                     )
                 ]
             },
-            None,
+            (None, None),
             id="missing_name",
         ),
         pytest.param(
@@ -673,7 +674,7 @@ def test_artist_torrent_group_matchable(group_name: str, expected_result: bool) 
                     )
                 ]
             },
-            None,
+            (None, None),
             id="low_score_match",
         ),
         pytest.param(
@@ -687,13 +688,13 @@ def test_artist_torrent_group_matchable(group_name: str, expected_result: bool) 
                     )
                 ]
             },
-            None,
+            (None, None),
             id="low_score_match",
         ),
     ],
 )
 def test_match_artist_album_edge_cases(
-    log: FakeLogger, album: FakeAlbum, group_config: dict, expected: tuple | None
+    log: FakeLogger, album: FakeAlbum, group_config: dict, expected: Union[tuple[RedArtistTorrentGroup, RedArtistTorrent], None]
 ) -> None:
     """Test match_artist_album with parameterized edge cases."""
     response = RedArtistResponse(
@@ -791,7 +792,7 @@ def test_beets_fields_from_artist_torrent_groups(
     ],
 )
 def test_get_artist_id_from_red_group_exceptions(
-    log: FakeLogger, group_config: dict, torrent_config: dict, expected_result: int | None
+    log: FakeLogger, group_config: dict, torrent_config: dict, expected_result: Union[int, None]
 ) -> None:
     """Test exception handling in get_artist_id_from_red_group with parameterized inputs."""
     from beetsplug.redacted.search import get_artist_id_from_red_group


### PR DESCRIPTION
Add a GitHub workflow that runs the presubmit checks on a matrix of Python 3.9 and the latest python, and the latest versions of macos, windows, and ubuntu.

This required changing the "type | None" type expression to the older style "Union[type | None]" for Python 3.9 compatibility.