### PR TITLE
Prioritize torrents from the user's "snatched" history for matching.

### DIFF
--- a/beetsplug/redacted/__init__.py
+++ b/beetsplug/redacted/__init__.py
@@ -3,18 +3,19 @@
 
 import time
 from pkgutil import extend_path
-from typing import Union
+from typing import Optional, Union
 
 import frozendict
 from beets.dbcore import types as dbtypes  # type: ignore[import-untyped]
 from beets.importer import ImportTask  # type: ignore[import-untyped]
-from beets.library import Library  # type: ignore[import-untyped]
+from beets.library import Album, Item, Library  # type: ignore[import-untyped]
 from beets.plugins import BeetsPlugin  # type: ignore[import-untyped]
 from beets.ui import UserError  # type: ignore[import-untyped]
 
 from beetsplug.redacted.client import Client
 from beetsplug.redacted.command import RedactedCommand
 from beetsplug.redacted.http import CachedRequestsClient, HTTPClient
+from beetsplug.redacted.metadata import candidates
 from beetsplug.redacted.search import search
 
 __path__ = extend_path(__path__, __name__)
@@ -88,6 +89,8 @@ class RedactedPlugin(BeetsPlugin):
     def import_stage(self, _: Library, task: ImportTask) -> bool:
         """Process an album during import.
 
+        Adds Redacted metadata to the album.
+
         Args:
             _: Library instance
             album: Album instance
@@ -127,3 +130,15 @@ class RedactedPlugin(BeetsPlugin):
 
         client = Client(api_key, self._http_client, self._log)
         return [RedactedCommand(self.config, self._log, client)]
+
+    def candidates(
+        self,
+        items: list[Item],
+        artist: str,
+        album: str,
+        va_likely: bool,
+        extra_tags: Optional[dict[str, str]] = None,
+    ) -> list[Album]:
+        return candidates(
+            self.client, self.log, items, artist, album, va_likely, extra_tags=extra_tags
+        )

--- a/beetsplug/redacted/__init__.py
+++ b/beetsplug/redacted/__init__.py
@@ -12,7 +12,7 @@ from beets.library import Library  # type: ignore[import-untyped]
 from beets.plugins import BeetsPlugin  # type: ignore[import-untyped]
 from beets.ui import UserError  # type: ignore[import-untyped]
 
-from beetsplug.redacted.client import RedactedClient
+from beetsplug.redacted.client import Client
 from beetsplug.redacted.command import RedactedCommand
 from beetsplug.redacted.http import CachedRequestsClient, HTTPClient
 from beetsplug.redacted.search import search
@@ -73,13 +73,13 @@ class RedactedPlugin(BeetsPlugin):
         if self._client and self.config["auto"].get(bool):
             self.import_stages = [self.import_stage]
 
-    def _get_client(self, http_client: HTTPClient) -> Union[RedactedClient, None]:
+    def _get_client(self, http_client: HTTPClient) -> Union[Client, None]:
         """Get or create the RedactedClient instance."""
         api_key = self.config["api_key"].get()
         if not api_key:
             self._log.warning("redacted: api_key not set in configuration.")
             return None
-        return RedactedClient(api_key, http_client, self._log)
+        return Client(api_key, http_client, self._log)
 
     def cleanup(self, _: Library) -> None:
         """Clean up resources when Beets is shutting down."""
@@ -125,5 +125,5 @@ class RedactedPlugin(BeetsPlugin):
         if not api_key:
             raise UserError("redacted: api_key not set")
 
-        client = RedactedClient(api_key, self._http_client, self._log)
+        client = Client(api_key, self._http_client, self._log)
         return [RedactedCommand(self.config, self._log, client)]

--- a/beetsplug/redacted/client.py
+++ b/beetsplug/redacted/client.py
@@ -3,33 +3,49 @@ Main client class for interacting with Redacted.
 """
 
 import logging
-from typing import Any
+from typing import Any, Optional
 
 from pydantic import ValidationError
 
 from .exceptions import RedactedError
 from .http import HTTPClient
-from .types import RedAction, RedArtistResponse, RedSearchResponse
+from .types import (
+    Action,
+    RedArtistResponse,
+    RedSearchResponse,
+    RedUserResponse,
+    RedUserResponseResults,
+    TorrentType,
+)
 
 
 class Client:
     """Client for interacting with the Redacted private tracker."""
 
-    def __init__(self, api_key: str, http_client: HTTPClient, log: logging.Logger) -> None:
+    def __init__(
+        self,
+        http_client: HTTPClient,
+        log: logging.Logger,
+        api_key: str,
+        user_id: Optional[str] = None,
+    ) -> None:
         """Initialize the client.
 
         Args:
             api_key: API key for authentication.
             http_client: HTTP client implementation.
             log: Logger instance for logging messages.
+            user_id: User ID for the user to get torrents for. If None, then the #user method will
+                always return an empty list.
         """
         self.log = log
         self.log.debug("Initializing RedactedClient")
 
-        self.api_key = api_key
         self.http_client = http_client
+        self.api_key = api_key
+        self.user_id = user_id
 
-    def _make_api_request(self, action: RedAction, params: dict[str, str]) -> dict[str, Any]:
+    def _make_api_request(self, action: Action, params: dict[str, str]) -> dict[str, Any]:
         """Make an API request to Redacted.
 
         Args:
@@ -63,6 +79,87 @@ class Client:
     def search(self, query: str) -> RedSearchResponse:
         """Search for torrents on Redacted.
 
+        URL: ajax.php?action=browse&searchstr=<Search Term>
+
+        Arguments:
+        searchstr - string to search for
+        page - page to display (default: 1)
+        taglist, tags_type, order_by, order_way, filter_cat, freetorrent, vanityhouse, scene,
+        haslog, releasetype, media, format, encoding, artistname, filelist, groupname, recordlabel,
+        cataloguenumber, year, remastertitle, remasteryear, remasterrecordlabel,
+        remastercataloguenumber - as in advanced search
+
+        Response format:
+
+        ```json
+        {
+            "status": "success",
+            "response": {
+                "currentPage": 1,
+                "pages": 3,
+                "results": [
+                    {
+                        "groupId": 410618,
+                        "groupName": "Jungle Music / Toytown",
+                        "artist": "Logistics",
+                        "tags": [
+                            "drum.and.bass",
+                            "electronic"
+                        ],
+                        "bookmarked": false,
+                        "vanityHouse": false,
+                        "groupYear": 2009,
+                        "releaseType": "Single",
+                        "groupTime": 1339117820,
+                        "maxSize": 237970,
+                        "totalSnatched": 318,
+                        "totalSeeders": 14,
+                        "totalLeechers": 0,
+                        "torrents": [
+                            {
+                                "torrentId": 959473,
+                                "editionId": 1,
+                                "artists": [
+                                    {
+                                        "id": 1460,
+                                        "name": "Logistics",
+                                        "aliasid": 1460
+                                    }
+                                ],
+                                "remastered": false,
+                                "remasterYear": 0,
+                                "remasterCatalogueNumber": "",
+                                "remasterTitle": "",
+                                "media": "Vinyl",
+                                "encoding": "24bit Lossless",
+                                "format": "FLAC",
+                                "hasLog": false,
+                                "logScore": 79,
+                                "hasCue": false,
+                                "scene": false,
+                                "vanityHouse": false,
+                                "fileCount": 3,
+                                "time": "2009-06-06 19:04:22",
+                                "size": 243680994,
+                                "snatches": 10,
+                                "seeders": 3,
+                                "leechers": 0,
+                                "isFreeleech": false,
+                                "isNeutralLeech": false,
+                                "isFreeload": false,
+                                "isPersonalFreeleech": false,
+                                "trumpable": false,
+                                "canUseToken": true
+                            },
+                            // ...
+                        ]
+                    },
+                    // ...
+                ]
+            }
+        }
+        ```
+
         Args:
             query: Search query string. Can be a general search term, an artist name,
                   or in the format "Artist - Album" for specific album searches.
@@ -73,7 +170,7 @@ class Client:
         Raises:
             RedactedError: If the response is not in the expected format or indicates failure.
         """
-        response = self._make_api_request(RedAction.BROWSE, {"searchstr": query})
+        response = self._make_api_request(Action.BROWSE, {"searchstr": query})
         try:
             return RedSearchResponse(**response)
         except ValidationError as e:
@@ -87,6 +184,104 @@ class Client:
     def get_artist(self, artist_id: int) -> RedArtistResponse:
         """Get detailed information about an artist by ID.
 
+        URL: ajax.php?action=artist&id=<Artist Id>
+
+        Arguments:
+        id - artist's id
+        artistname - Artist's Name
+        artistreleases - if set, only include groups where the artist is the main artist.
+
+        Response format:
+
+        ```json
+        {
+            "status": "success",
+            "response": {
+                "id": 1460,
+                "name": "Logistics",
+                "notificationsEnabled": false,
+                "hasBookmarked": true,
+                "image": "http://img120.imageshack.us/img120/3206/logiop1.jpg",
+                "body": "",
+                "vanityHouse": false,
+                "tags": [
+                    {
+                        "name": "breaks",
+                        "count": 3
+                    },
+                    // ...
+                ],
+                "similarArtists": [],
+                "statistics": {
+                    "numGroups": 125,
+                    "numTorrents": 443,
+                    "numSeeders": 3047,
+                    "numLeechers": 95,
+                    "numSnatches": 28033
+                },
+                "torrentgroup": [
+                    {
+                        "groupId": 72189681,
+                        "groupName": "Fear Not",
+                        "groupYear": 2012,
+                        "groupRecordLabel": "Hospital Records",
+                        "groupCatalogueNumber": "NHS209CD",
+                        "tags": [
+                            "breaks",
+                            "drum.and.bass",
+                            "electronic",
+                            "dubstep"
+                        ],
+                        "releaseType": 1,
+                        "groupVanityHouse": false,
+                        "hasBookmarked": false,
+                        "torrent": [
+                            {
+                                "id": 29991962,
+                                "groupId": 72189681,
+                                "media": "CD",
+                                "format": "FLAC",
+                                "encoding": "Lossless",
+                                "remasterYear": 0,
+                                "remastered": false,
+                                "remasterTitle": "",
+                                "remasterRecordLabel": "",
+                                "scene": true,
+                                "hasLog": false,
+                                "hasCue": false,
+                                "logScore": 0,
+                                "fileCount": 19,
+                                "freeTorrent": false,
+                                "isNeutralleech": false,
+                                "isFreeload": false,
+                                "size": 527749302,
+                                "leechers": 0,
+                                "seeders": 20,
+                                "snatched": 55,
+                                "time": "2012-04-14 15:57:00",
+                                "hasFile": 29991962
+                            },
+                            // ...
+                        ]
+                    },
+                    // ...
+                ],
+                "requests": [
+                    {
+                        "requestId": 172667,
+                        "categoryId": 1,
+                        "title": "We Are One (Nu:logic Remix)/timelapse",
+                        "year": 2012,
+                        "timeAdded": "2012-02-07 03:44:39",
+                        "votes": 3,
+                        "bounty": 217055232
+                    },
+                    // ...
+                ]
+            }
+        }
+        ```
+
         Args:
             artist_id: The artist ID to look up.
 
@@ -96,7 +291,7 @@ class Client:
         Raises:
             RedactedError: If the response is not in the expected format or indicates failure.
         """
-        response = self._make_api_request(RedAction.ARTIST, {"id": str(artist_id)})
+        response = self._make_api_request(Action.ARTIST, {"id": str(artist_id)})
 
         if response["status"] == "failure":
             raise RedactedError(f"API error: {response.get('error', 'Unknown error')}")
@@ -109,4 +304,72 @@ class Client:
             self.log.debug(
                 "Couldn't parse RedactedArtistResponse from:\n%s", json.dumps(response, indent=2)
             )
+            raise RedactedError(f"Invalid response format: {e}") from e
+
+    def user(self, type: TorrentType, limit: int = 500, offset: int = 0) -> RedUserResponse:
+        """Get user torrents by type.
+
+        Calls Redacted's 'user_torrents' API endpoint.
+
+        URL: ajax.php?action=user_torrents&id=<User ID>
+                     &type=<Torrent Type>
+                     &limit=<Results Limit>
+                     &offset=<Torrents Offset>
+
+        Arguments:
+        id - request id
+        type - type of torrents to display options are: seeding leeching uploaded snatched
+        limit - number of results to display (default: 500)
+        offset - number of results to offset by (default: 0)
+
+        Response format:
+
+        ```json
+        {
+            "status": "success",
+            "response": {
+                "seeding": [
+                    {
+                        "groupId": "4",
+                        "name": "If You Have Ghost",
+                        "torrentId": "4",
+                        "artistName": "Ghost B.C.",
+                        "artistId": "4"
+                    },
+                    {
+                        "groupId": "3",
+                        "name": "Absolute Dissent",
+                        "torrentId": "3",
+                        "artistName": "Killing Joke",
+                        "artistId": "3"
+                    }
+                ]
+            }
+        }
+        ```
+
+        Args:
+            type: The type of torrents to get.
+            limit: The number of torrents to get.
+            offset: The offset to start from.
+        """
+        if not self.user_id:
+            return RedUserResponse(
+                status="success",
+                response=RedUserResponseResults(seeding=[], leeching=[], uploaded=[], snatched=[]),
+            )
+
+        response = self._make_api_request(
+            Action.USER_TORRENTS,
+            {
+                "id": str(self.user_id),
+                "type": type.value,
+                "limit": str(limit),
+                "offset": str(offset),
+            },
+        )
+        try:
+            return RedUserResponse(**response)
+        except ValidationError as e:
+            self.log.debug("Couldn't parse RedactedUserResponse from:\n%s", response)
             raise RedactedError(f"Invalid response format: {e}") from e

--- a/beetsplug/redacted/client.py
+++ b/beetsplug/redacted/client.py
@@ -12,7 +12,7 @@ from .http import HTTPClient
 from .types import RedAction, RedArtistResponse, RedSearchResponse
 
 
-class RedactedClient:
+class Client:
     """Client for interacting with the Redacted private tracker."""
 
     def __init__(self, api_key: str, http_client: HTTPClient, log: logging.Logger) -> None:
@@ -60,7 +60,7 @@ class RedactedClient:
 
         return data
 
-    def browse(self, query: str) -> RedSearchResponse:
+    def search(self, query: str) -> RedSearchResponse:
         """Search for torrents on Redacted.
 
         Args:

--- a/beetsplug/redacted/command.py
+++ b/beetsplug/redacted/command.py
@@ -11,7 +11,7 @@ import enlighten  # type: ignore[import-untyped]
 from beets import ui  # type: ignore[import-untyped]
 from beets.library import Library  # type: ignore[import-untyped]
 
-from beetsplug.redacted.client import RedactedClient
+from beetsplug.redacted.client import Client
 from beetsplug.redacted.search import search
 
 
@@ -20,7 +20,7 @@ def command_func(
     lib: Library,
     opts: Values,
     args: list[str],
-    client: RedactedClient,
+    client: Client,
     log: logging.Logger,
 ) -> dict[str, int]:
     """Execute the redacted command.
@@ -94,7 +94,7 @@ def command_func(
 class RedactedCommand(ui.Subcommand):
     """Command for searching and updating Redacted information for library albums."""
 
-    def __init__(self, config: Any, log: logging.Logger, client: RedactedClient) -> None:
+    def __init__(self, config: Any, log: logging.Logger, client: Client) -> None:
         """Initialize the command.
 
         Args:

--- a/beetsplug/redacted/command.py
+++ b/beetsplug/redacted/command.py
@@ -5,7 +5,7 @@ import logging
 import sys
 import time
 from optparse import OptionParser, Values
-from typing import Any
+from typing import Any, Optional
 
 import enlighten  # type: ignore[import-untyped]
 from beets import ui  # type: ignore[import-untyped]
@@ -37,7 +37,7 @@ def command_func(
     query = " ".join(args) if args else ""
 
     # Filter query to only include albums without red_groupid if force=False
-    if not opts.force:
+    if not opts.ensure_value("force", False):
         query = f"{query} red_groupid::^$"
 
     # Get the albums to process from the Beets database
@@ -94,7 +94,7 @@ def command_func(
 class RedactedCommand(ui.Subcommand):
     """Command for searching and updating Redacted information for library albums."""
 
-    def __init__(self, config: Any, log: logging.Logger, client: Client) -> None:
+    def __init__(self, config: Any, log: logging.Logger, client: Optional[Client] = None) -> None:
         """Initialize the command.
 
         Args:
@@ -106,25 +106,33 @@ class RedactedCommand(ui.Subcommand):
         self.log = log
         self.client = client
 
+        default_opts = {
+            "min_score": config["min_score"].as_number(),
+            "pretend": False,
+            "force": False,
+        }
+
         # Create the command parser
         parser = OptionParser(usage="beet redacted [options] [QUERY...]")
         parser.add_option(
             "--min-score",
             dest="min_score",
             type="float",
-            default=config["min_score"].as_number(),
+            default=default_opts["min_score"],
             help="Minimum match score to consider (0-1, default: 0.75)",
         )
         parser.add_option(
             "-p",
             "--pretend",
             action="store_true",
+            default=default_opts["pretend"],
             help="Show what would be updated without making changes",
         )
         parser.add_option(
             "-f",
             "--force",
             action="store_true",
+            default=default_opts["force"],
             help="Search all albums even if they already have a red_groupid",
         )
 
@@ -136,6 +144,26 @@ class RedactedCommand(ui.Subcommand):
         )
 
         # Bind the logger and client to the command function
-        self.func = lambda lib, opts, args: command_func(
-            self, lib, opts, args, self.client, self.log
-        )
+        if self.client:
+
+            def ensure_values(opts: Values, default: dict[str, Any]) -> Values:
+                for key, value in default.items():
+                    opts.ensure_value(key, value)
+                return opts
+
+            def func(lib: Library, opts: Values, args: list[str]) -> dict[str, int]:
+                assert self.client is not None
+
+                opts = ensure_values(opts, default_opts)
+                return command_func(self, lib, opts, args, self.client, self.log)
+
+            self.func = func
+        else:
+
+            def func(lib: Library, opts: Values, args: list[str]) -> dict[str, int]:
+                raise ui.UserError(
+                    "Could not construct Client for Redacted API requests. Have you set "
+                    "the required 'api_key' in the redacted plugin configuration?"
+                )
+
+            self.func = func

--- a/beetsplug/redacted/matching.py
+++ b/beetsplug/redacted/matching.py
@@ -76,7 +76,7 @@ def extract_album_fields(album: Album) -> Matchable:
     Returns:
         MatchableFields object with normalized fields
     """
-    assert isinstance(album, Album)
+    assert isinstance(album, Album), f"album must be a Beets Album, got {type(album)}"
     if "year" in album:
         year = album.get("year", None)
         if year == 0:

--- a/beetsplug/redacted/metadata.py
+++ b/beetsplug/redacted/metadata.py
@@ -1,0 +1,66 @@
+"""Metadata plugin for Redacted.
+
+Provides metadata matches for the autotagger from Redacted's API.
+"""
+
+import logging
+from typing import Optional
+
+from beets.library import Album, Item
+
+from beetsplug.redacted import client
+from beetsplug.redacted.utils.search_utils import normalize_query
+
+
+def candidates(
+    client: client.Client,
+    log: logging.Logger,
+    items: list[Item],
+    artist: str,
+    album: str,
+    va_likely: bool,
+    extra_tags: Optional[dict[str, str]] = None,
+) -> list[Album]:
+    """Return a list of Albums that are candidate matches for a release.
+
+    Args:
+        client: The Redacted client to use for searching
+        items: The items to match
+        artist: The artist to search for
+        album: The album to search for
+        va_likely: Whether this is likely a Various Artists album
+        extra_tags: Additional tags to add to the album
+
+    Returns:
+        A list of Albums that are candidate matches
+    """
+    # Skip VA albums as they require special handling
+    if va_likely:
+        return []
+
+    # Normalize the search query
+    query = normalize_query(artist, album, log)
+    if not query:
+        return []
+
+    try:
+        # Search for the album on Redacted
+        response = client.search(query)
+        if not response or not response.response or not response.response.results:
+            return []
+
+        # Convert the search results to Beets Album objects
+        albums = []
+        for result in response.response.results:
+            album: Album = Album()
+            album.red_groupid = result.groupId
+            album.albumartist = result.artist
+            album.album = result.groupName
+            album.year = result.groupYear
+            albums.append(album)
+
+        return albums
+
+    except Exception as e:
+        log.error(f"Error searching Redacted: {e}")
+        return []

--- a/beetsplug/redacted/metadata.py
+++ b/beetsplug/redacted/metadata.py
@@ -6,7 +6,7 @@ Provides metadata matches for the autotagger from Redacted's API.
 import logging
 from typing import Optional
 
-from beets.library import Album, Item
+from beets.library import Album, Item  # type: ignore[import-untyped]
 
 from beetsplug.redacted import client
 from beetsplug.redacted.utils.search_utils import normalize_query
@@ -52,12 +52,11 @@ def candidates(
         # Convert the search results to Beets Album objects
         albums = []
         for result in response.response.results:
-            album: Album = Album()
-            album.red_groupid = result.groupId
-            album.albumartist = result.artist
-            album.album = result.groupName
-            album.year = result.groupYear
-            albums.append(album)
+            candidate = Album()
+            candidate.albumartist = result.artist
+            candidate.album = result.groupName
+            candidate.year = result.groupYear
+            albums.append(candidate)
 
         return albums
 

--- a/beetsplug/redacted/search.py
+++ b/beetsplug/redacted/search.py
@@ -9,7 +9,7 @@ from beets.library import Album  # type: ignore[import-untyped]
 from pydantic import ValidationError
 from ratelimit import RateLimitException  # type: ignore[import-untyped]
 
-from beetsplug.redacted.client import RedactedClient
+from beetsplug.redacted.client import Client
 from beetsplug.redacted.exceptions import RedactedError
 from beetsplug.redacted.matching import Matchable, extract_album_fields, score_match
 from beetsplug.redacted.types import (
@@ -337,7 +337,7 @@ def beets_fields_from_artist_torrent_groups(
 
 
 def search(
-    album: Album, client: RedactedClient, log: logging.Logger, min_score: float
+    album: Album, client: Client, log: logging.Logger, min_score: float
 ) -> Union[BeetsRedFields, None]:
     """Search for Redacted torrents matching an album using a two-step process.
 
@@ -369,7 +369,7 @@ def search(
 
         try:
             log.debug("Searching for torrents with query: {0}", search_query)
-            results = client.browse(search_query)
+            results = client.search(search_query)
         except (RedactedError, RateLimitException) as e:
             log.debug(
                 "Error searching for torrents for {0} - {1}: {2}", album.albumartist, album.album, e

--- a/beetsplug/redacted/types.py
+++ b/beetsplug/redacted/types.py
@@ -183,12 +183,22 @@ from typing import Generic, Literal, TypeVar, Union
 from pydantic.dataclasses import dataclass
 
 
-class RedAction(Enum):
+class Action(Enum):
     """Valid actions for the Redacted API."""
 
     BROWSE = "browse"
     REQUESTS = "requests"
     ARTIST = "artist"
+    USER_TORRENTS = "user_torrents"
+
+
+class TorrentType(Enum):
+    """Valid types for user torrents."""
+
+    SEEDING = "seeding"
+    LEECHING = "leeching"
+    UPLOADED = "uploaded"
+    SNATCHED = "snatched"
 
 
 @dataclass
@@ -411,6 +421,32 @@ class RedArtistResponse(RedSuccessResponse):
     """Type for the artist response from Redacted API."""
 
     response: RedArtistResponseResults
+
+
+@dataclass
+class RedUserTorrent:
+    """Type for a user torrent."""
+
+    groupId: int
+    name: str
+    torrentId: int
+    artistName: str
+    artistId: int
+
+
+@dataclass
+class RedUserResponseResults:
+    seeding: list[RedUserTorrent]
+    leeching: list[RedUserTorrent]
+    uploaded: list[RedUserTorrent]
+    snatched: list[RedUserTorrent]
+
+
+@dataclass
+class RedUserResponse(RedSuccessResponse):
+    """Type for the user response from Redacted API."""
+
+    response: RedUserResponseResults
 
 
 RedactedAPIResponse = Union[RedSearchResponse, RedArtistResponse, RedFailureResponse]

--- a/beetsplug/redacted/utils/test_utils.py
+++ b/beetsplug/redacted/utils/test_utils.py
@@ -398,7 +398,8 @@ class FakeLogger(logging.Logger):
     def __init__(self) -> None:
         """Initialize fake logger."""
         super().__init__("fake")
-        self.messages: list[str] = []
+        self.logger = logging.getLogger("FakeLogger")
+        self.messages: list[tuple[str, tuple[Any]]] = []
 
     def debug(self, msg: str, *args: Any) -> None:  # type: ignore[override]
         """Log a debug message.
@@ -407,7 +408,8 @@ class FakeLogger(logging.Logger):
             msg: Message to log
             args: Format arguments
         """
-        self.messages.append(msg.format(*args))
+        self.logger.debug(msg.format(*args))
+        self.messages.append((msg, args))
 
     def info(self, msg: str, *args: Any) -> None:  # type: ignore[override]
         """Log an info message.
@@ -416,7 +418,8 @@ class FakeLogger(logging.Logger):
             msg: Message to log
             args: Format arguments
         """
-        self.messages.append(msg.format(*args))
+        self.logger.info(msg.format(*args))
+        self.messages.append((msg, args))
 
     def error(self, msg: str, *args: Any) -> None:  # type: ignore[override]
         """Log an error message.
@@ -425,16 +428,18 @@ class FakeLogger(logging.Logger):
             msg: Message to log
             args: Format arguments
         """
-        self.messages.append(msg.format(*args))
+        self.logger.error(msg.format(*args))
+        self.messages.append((msg, args))
 
-    def assert_message(self, msg: str) -> None:
+    def assert_message(self, msg: str, args: tuple[Any, ...]) -> None:
         """Assert that a message was logged.
 
         Args:
             msg: Message to check for. This can be a substring of the actual message.
+            args: Format arguments
         """
         for message in self.messages:
-            if msg in message:
+            if msg in message[0] and args == message[1]:
                 return
         raise AssertionError(f"Expected message containing '{msg}' not found in {self.messages}")
 

--- a/beetsplug/redacted/utils/test_utils.py
+++ b/beetsplug/redacted/utils/test_utils.py
@@ -75,7 +75,7 @@ import requests
 from beets import library  # type: ignore[import-untyped]
 from beets.library import Album  # type: ignore[import-untyped]
 
-from beetsplug.redacted.client import RedactedClient
+from beetsplug.redacted.client import Client
 from beetsplug.redacted.exceptions import RedactedError
 from beetsplug.redacted.http import HTTPClient
 from beetsplug.redacted.types import (
@@ -523,7 +523,7 @@ class FakeHTTPClient(HTTPClient):
         return self.responses[request_hash]
 
 
-class FakeRedactedClient(RedactedClient):
+class FakeClient(Client):
     """Fake implementation of RedactedClient for testing."""
 
     def __init__(self) -> None:
@@ -537,7 +537,7 @@ class FakeRedactedClient(RedactedClient):
         self.error_artist_queries: set[int] = set()
         self.rate_limit_artist_queries: set[int] = set()
 
-    def browse(self, query: str) -> RedSearchResponse:
+    def search(self, query: str) -> RedSearchResponse:
         """Fake implementation of browse method.
 
         Args:

--- a/beetsplug/redacted/utils/test_utils.py
+++ b/beetsplug/redacted/utils/test_utils.py
@@ -69,7 +69,7 @@ import copy
 import logging
 from collections.abc import Generator, Sequence
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Protocol, Union
+from typing import TYPE_CHECKING, Any, Optional, Protocol, Union
 
 import requests
 from beets import library  # type: ignore[import-untyped]
@@ -83,6 +83,9 @@ from beetsplug.redacted.types import (
     RedArtistResponseResults,
     RedSearchResponse,
     RedSearchResults,
+    RedUserResponse,
+    RedUserResponseResults,
+    TorrentType,
 )
 
 # Forward declaration for type checking
@@ -530,6 +533,7 @@ class FakeClient(Client):
         """Initialize the fake client."""
         self.search_responses: dict[str, RedSearchResponse] = {}
         self.artist_responses: dict[int, RedArtistResponse] = {}
+        self.user_response: Optional[RedUserResponse] = None
         self.queries: list[str] = []
         self.error_queries: set[str] = set()
         self.rate_limit_queries: set[str] = set()
@@ -593,6 +597,13 @@ class FakeClient(Client):
             )
 
         return self.artist_responses[artist_id]
+
+    def user(self, _: TorrentType, limit: int = 500, offset: int = 0) -> RedUserResponse:
+        """Fake implementation of user torrents lookup (snatched, seeding, etc)."""
+        if self.user_response:
+            return self.user_response
+
+        raise RedactedError("Fake user lookup failure")
 
 
 class FakeCommandOpts:

--- a/tests/beetsplug/redacted/test_client.py
+++ b/tests/beetsplug/redacted/test_client.py
@@ -7,7 +7,7 @@ import pytest
 
 from beetsplug.redacted.client import Client
 from beetsplug.redacted.exceptions import RedactedError
-from beetsplug.redacted.types import RedAction
+from beetsplug.redacted.types import Action
 from beetsplug.redacted.utils.test_utils import FakeHTTPClient, FakeLogger
 
 
@@ -39,7 +39,7 @@ def test_make_api_request_success(client: Client) -> None:
         response={"status": "success", "response": {"test": "data"}},
     )
 
-    response = client._make_api_request(RedAction.BROWSE, {})
+    response = client._make_api_request(Action.BROWSE, {})
     assert response == {"status": "success", "response": {"test": "data"}}
 
 
@@ -54,7 +54,7 @@ def test_make_api_request_rate_limit(client: Client) -> None:
     )
 
     with pytest.raises(RedactedError):
-        client._make_api_request(RedAction.BROWSE, {})
+        client._make_api_request(Action.BROWSE, {})
 
 
 def test_make_api_request_json_parse_error(client: Client) -> None:
@@ -67,7 +67,7 @@ def test_make_api_request_json_parse_error(client: Client) -> None:
     )
 
     with pytest.raises(RedactedError):
-        client._make_api_request(RedAction.BROWSE, {})
+        client._make_api_request(Action.BROWSE, {})
 
 
 def test_browse(client: Client) -> None:

--- a/tests/beetsplug/redacted/test_client.py
+++ b/tests/beetsplug/redacted/test_client.py
@@ -5,7 +5,7 @@ from collections.abc import Generator
 
 import pytest
 
-from beetsplug.redacted.client import RedactedClient
+from beetsplug.redacted.client import Client
 from beetsplug.redacted.exceptions import RedactedError
 from beetsplug.redacted.types import RedAction
 from beetsplug.redacted.utils.test_utils import FakeHTTPClient, FakeLogger
@@ -18,7 +18,7 @@ def log():
 
 
 @pytest.fixture
-def client(log: FakeLogger) -> Generator[RedactedClient, None, None]:
+def client(log: FakeLogger) -> Generator[Client, None, None]:
     """Create a test client.
 
     Args:
@@ -27,10 +27,10 @@ def client(log: FakeLogger) -> Generator[RedactedClient, None, None]:
     Yields:
         A RedactedClient instance configured for testing.
     """
-    yield RedactedClient(api_key="test_key", http_client=FakeHTTPClient(), log=log)
+    yield Client(api_key="test_key", http_client=FakeHTTPClient(), log=log)
 
 
-def test_make_api_request_success(client: RedactedClient) -> None:
+def test_make_api_request_success(client: Client) -> None:
     """Test making a successful API request."""
     assert isinstance(client.http_client, FakeHTTPClient)
     client.http_client.add(
@@ -43,7 +43,7 @@ def test_make_api_request_success(client: RedactedClient) -> None:
     assert response == {"status": "success", "response": {"test": "data"}}
 
 
-def test_make_api_request_rate_limit(client: RedactedClient) -> None:
+def test_make_api_request_rate_limit(client: Client) -> None:
     """Test making an API request that hits rate limit."""
     assert isinstance(client.http_client, FakeHTTPClient)
     client.http_client.add(
@@ -57,7 +57,7 @@ def test_make_api_request_rate_limit(client: RedactedClient) -> None:
         client._make_api_request(RedAction.BROWSE, {})
 
 
-def test_make_api_request_json_parse_error(client: RedactedClient) -> None:
+def test_make_api_request_json_parse_error(client: Client) -> None:
     """Test making an API request with invalid JSON response."""
     assert isinstance(client.http_client, FakeHTTPClient)
     client.http_client.add(
@@ -70,7 +70,7 @@ def test_make_api_request_json_parse_error(client: RedactedClient) -> None:
         client._make_api_request(RedAction.BROWSE, {})
 
 
-def test_browse(client: RedactedClient) -> None:
+def test_browse(client: Client) -> None:
     """Test browsing torrents."""
     assert isinstance(client.http_client, FakeHTTPClient)
     mock_response = {
@@ -132,7 +132,7 @@ def test_browse(client: RedactedClient) -> None:
         response=mock_response,
     )
 
-    response = client.browse("test query")
+    response = client.search("test query")
     assert response.status == "success"
     assert len(response.response.results) == 1
     result = response.response.results[0]
@@ -146,7 +146,7 @@ def test_browse(client: RedactedClient) -> None:
     assert torrent.format == "FLAC"
 
 
-def test_browse_validation_error(client: RedactedClient) -> None:
+def test_browse_validation_error(client: Client) -> None:
     """Test handling validation errors when browsing torrents."""
     assert isinstance(client.http_client, FakeHTTPClient)
     # Missing required fields in the response
@@ -176,11 +176,11 @@ def test_browse_validation_error(client: RedactedClient) -> None:
     )
 
     with pytest.raises(RedactedError) as excinfo:
-        client.browse("test query")
+        client.search("test query")
     assert "Invalid response format" in str(excinfo.value)
 
 
-def test_get_artist(client: RedactedClient) -> None:
+def test_get_artist(client: Client) -> None:
     """Test getting artist details by ID."""
     assert isinstance(client.http_client, FakeHTTPClient)
     mock_response = {
@@ -269,7 +269,7 @@ def test_get_artist(client: RedactedClient) -> None:
     assert response.response.torrentgroup[0].torrent[0].id == 98765
 
 
-def test_get_artist_validation_error(client: RedactedClient) -> None:
+def test_get_artist_validation_error(client: Client) -> None:
     """Test handling validation errors when getting artist details."""
     assert isinstance(client.http_client, FakeHTTPClient)
     # Missing required fields in the response
@@ -285,7 +285,7 @@ def test_get_artist_validation_error(client: RedactedClient) -> None:
     assert "Invalid response format" in str(excinfo.value)
 
 
-def test_get_artist_error_response(client: RedactedClient) -> None:
+def test_get_artist_error_response(client: Client) -> None:
     """Test handling error response when getting artist details."""
     assert isinstance(client.http_client, FakeHTTPClient)
     mock_response = {"status": "failure", "error": "Artist not found"}

--- a/tests/beetsplug/redacted/test_command.py
+++ b/tests/beetsplug/redacted/test_command.py
@@ -10,11 +10,11 @@ from beetsplug.redacted.command import RedactedCommand
 from beetsplug.redacted.search import BeetsRedFields
 from beetsplug.redacted.utils.test_utils import (
     FakeAlbum,
+    FakeClient,
     FakeCommandOpts,
     FakeConfig,
     FakeLibrary,
     FakeLogger,
-    FakeClient,
 )
 
 

--- a/tests/beetsplug/redacted/test_command.py
+++ b/tests/beetsplug/redacted/test_command.py
@@ -14,7 +14,7 @@ from beetsplug.redacted.utils.test_utils import (
     FakeConfig,
     FakeLibrary,
     FakeLogger,
-    FakeRedactedClient,
+    FakeClient,
 )
 
 
@@ -39,13 +39,13 @@ def album() -> FakeAlbum:
 
 
 @pytest.fixture
-def client() -> FakeRedactedClient:
+def client() -> FakeClient:
     """Create a fake client.
 
     Returns:
         A FakeRedactedClient instance
     """
-    return FakeRedactedClient()
+    return FakeClient()
 
 
 @pytest.fixture
@@ -115,7 +115,7 @@ def lib_with_red_groupid(test_album_data: dict[str, Any]) -> FakeLibrary:
 
 def test_command_init(config: FakeConfig, log: FakeLogger, lib: FakeLibrary) -> None:
     """Test command initialization."""
-    client = FakeRedactedClient()
+    client = FakeClient()
     command = RedactedCommand(config, log, client)
     assert command.name == "redacted"
     assert command.config == config
@@ -125,7 +125,7 @@ def test_command_init(config: FakeConfig, log: FakeLogger, lib: FakeLibrary) -> 
 
 def test_command_basic_execution(config: FakeConfig, log: FakeLogger, lib: FakeLibrary) -> None:
     """Test basic command execution searches torrents."""
-    client = FakeRedactedClient()
+    client = FakeClient()
     command = RedactedCommand(config, log, client)
     result = command.func(lib, FakeCommandOpts(), [])
 
@@ -137,7 +137,7 @@ def test_command_basic_execution(config: FakeConfig, log: FakeLogger, lib: FakeL
 
 def test_command_with_query(config: FakeConfig, lib: FakeLibrary, log: FakeLogger) -> None:
     """Test command execution with a query."""
-    command = RedactedCommand(config, log, FakeRedactedClient())
+    command = RedactedCommand(config, log, FakeClient())
     result = command.func(lib, FakeCommandOpts(), ["artist:testartist"])
 
     # Verify the return value
@@ -150,7 +150,7 @@ def test_command_with_unchanged_search_results_does_not_modify_albums(
     config: FakeConfig, log: FakeLogger, lib_with_red_groupid: FakeLibrary
 ) -> None:
     """Test command execution with force flag processes all albums."""
-    client = FakeRedactedClient()
+    client = FakeClient()
     command = RedactedCommand(config, log, client)
 
     # Mock search functions to return same values as album
@@ -175,7 +175,7 @@ def test_command_with_force(
     config: FakeConfig, log: FakeLogger, lib_with_red_groupid: FakeLibrary
 ) -> None:
     """Test command execution with force flag processes all albums."""
-    client = FakeRedactedClient()
+    client = FakeClient()
     command = RedactedCommand(config, log, client)
 
     # Verify that the library has at least one album.
@@ -197,7 +197,7 @@ def test_command_with_force(
 
 def test_command_without_force(config: FakeConfig, log: FakeLogger, lib: FakeLibrary) -> None:
     """Test command execution without force flag skips albums with red_groupid."""
-    client = FakeRedactedClient()
+    client = FakeClient()
     # Create a test album with existing red_groupid
     lib = FakeLibrary(
         [
@@ -231,7 +231,7 @@ def test_command_with_matches(
         # Set up mock return values
         mock_search.return_value = BeetsRedFields(red_groupid=1, red_torrentid=1)
 
-        command = RedactedCommand(config, log, FakeRedactedClient())
+        command = RedactedCommand(config, log, FakeClient())
         result = command.func(lib_with_album, FakeCommandOpts(), [])
 
         # Verify the return value
@@ -250,7 +250,7 @@ def test_command_pretend_mode(
         # Set up mock return values
         mock_search.return_value = BeetsRedFields(red_groupid=1, red_torrentid=1)
 
-        command = RedactedCommand(config, log, FakeRedactedClient())
+        command = RedactedCommand(config, log, FakeClient())
         # Execute command in pretend mode
         result = command.func(lib_with_album, FakeCommandOpts(pretend=True), [])
 

--- a/tests/beetsplug/redacted/test_init.py
+++ b/tests/beetsplug/redacted/test_init.py
@@ -10,10 +10,10 @@ from beetsplug.redacted import RedactedPlugin
 from beetsplug.redacted.types import BeetsRedFields
 from beetsplug.redacted.utils.test_utils import (
     FakeAlbum,
+    FakeClient,
     FakeConfig,
     FakeLibrary,
     FakeLogger,
-    FakeClient,
 )
 
 

--- a/tests/beetsplug/redacted/test_init.py
+++ b/tests/beetsplug/redacted/test_init.py
@@ -13,7 +13,7 @@ from beetsplug.redacted.utils.test_utils import (
     FakeConfig,
     FakeLibrary,
     FakeLogger,
-    FakeRedactedClient,
+    FakeClient,
 )
 
 
@@ -86,7 +86,7 @@ def test_import_stage_no_match_skips(log: FakeLogger, test_album: FakeAlbum) -> 
     """Test that import_stage skips albums with no match found."""
     plugin = RedactedPlugin()
     plugin._log = log
-    plugin._client = FakeRedactedClient()
+    plugin._client = FakeClient()
     plugin._min_score = 0.75
 
     # Create a task with an album
@@ -107,7 +107,7 @@ def test_import_stage_with_match_applies_fields(log: FakeLogger, test_album: Fak
     """Test that import_stage applies fields when a match is found."""
     plugin = RedactedPlugin()
     plugin._log = log
-    plugin._client = FakeRedactedClient()
+    plugin._client = FakeClient()
     plugin._min_score = 0.75
 
     # Create a task with an album
@@ -142,7 +142,7 @@ def test_import_stage_with_unchanged_fields_no_update(
     """Test that import_stage doesn't update if fields haven't changed."""
     plugin = RedactedPlugin()
     plugin._log = log
-    plugin._client = FakeRedactedClient()
+    plugin._client = FakeClient()
     plugin._min_score = 0.75
 
     # Set existing values on the album

--- a/tests/beetsplug/redacted/test_metadata.py
+++ b/tests/beetsplug/redacted/test_metadata.py
@@ -1,0 +1,130 @@
+"""Tests for the redacted metadata features.
+
+The Redacted plugin exposes metadata for us in the Beets import and autotagging pipeline.
+
+Documentation for plugins can be found here:
+  https://beets.readthedocs.io/en/stable/dev/plugins.html#extend-the-autotagger
+
+An example plugin implementation can be found here:
+  https://github.com/beetbox/beets/blob/master/beetsplug/chroma.py
+"""
+
+import pytest
+from beets.library import Item
+
+from beetsplug.redacted import metadata
+from beetsplug.redacted.types import RedSearchResponse, RedSearchResult, RedSearchResults
+from beetsplug.redacted.utils.test_utils import FakeClient, FakeLogger
+
+
+@pytest.fixture
+def log() -> FakeLogger:
+    """Create a fake logger for testing."""
+    return FakeLogger()
+
+
+@pytest.fixture
+def client() -> FakeClient:
+    """Create a fake Redacted client for testing."""
+    return FakeClient()
+
+
+
+def make_item(
+    artist: str = "Test Artist",
+    album: str = "Test Album",
+    title: str = "Test Track",
+    track: int = 1,
+) -> Item:
+    """Create a test Item with album information."""
+    return Item(
+        artist=artist,
+        album=album,
+        title=title,
+        track=track,
+        albumartist=artist,
+    )
+
+
+def make_result(
+    id: int = 1,
+    artist: str = "Test Artist",
+    name: str = "Test Album",
+    year: int = 2020,
+) -> RedSearchResult:
+    """Create a test torrent group."""
+    return RedSearchResult(
+        groupId=id,
+        artist=artist,
+        groupName=name,
+        groupYear=year,
+    )
+
+
+def test_candidates_no_matches(client: FakeClient, log: FakeLogger) -> None:
+    """Test that candidates returns empty list when no matches are found."""
+    items = [make_item()]
+    albums = metadata.candidates(client, log, items, "Test Artist", "Test Album", False)
+    assert len(albums) == 0
+    assert "Test Artist Test Album" in client.queries
+
+
+def test_candidates_with_matches(client: FakeClient, log: FakeLogger) -> None:
+    """Test that candidates returns albums when matches are found."""
+    items = [make_item()]
+    group_1 = make_result(artist="Test Artist", name="Test Album", year=2020)
+    group_2 = make_result(artist="Test Artist 2", name="Test Album 2")
+    client.search_responses["Test Artist Test Album"] = RedSearchResponse(
+        status="success",
+        response=RedSearchResults(results=[group_1, group_2]),
+    )
+
+    albums = metadata.candidates(client, log, items, "Test Artist", "Test Album", False)
+    assert len(albums) == 2
+
+    album = albums[0]
+    assert album.red_groupid == group_1.groupId
+    assert album.albumartist == group_1.artist
+    assert album.album == group_1.groupName
+    assert album.year == group_1.groupYear
+
+    album = albums[1]
+    assert album.red_groupid == group_2.groupId
+    assert album.albumartist == group_2.artist
+    assert album.album == group_2.groupName
+    assert album.year == group_2.groupYear
+
+
+def test_skips_va_albums(client: FakeClient, log: FakeLogger) -> None:
+    """Test that candidates skips VA albums."""
+    va_likely = True
+    albums = metadata.candidates(client, log, [], "Various Artists", "Test Album", va_likely)
+    assert len(albums) == 0
+
+def test_candidates_normalizes_query(
+    client: FakeClient,
+    log: FakeLogger
+) -> None:
+    """Test that candidates normalizes the search query."""
+    items = [make_item(artist="Test Artist (feat. Someone)", album="Test Album [Remastered]")]
+    client.search_responses["Test Artist Test Album"] = RedSearchResponse(
+        status="success",
+        response=RedSearchResults(results=[make_result()]),
+    )
+
+    albums = metadata.candidates(client, log, items, "Test Artist (feat. Someone)", "Test Album [Remastered]", False)
+    assert len(albums) == 1
+    assert "Test Artist Test Album" in client.queries
+
+
+
+def test_candidates_error_handling(
+    client: FakeClient,
+    log: FakeLogger
+) -> None:
+    """Test that candidates handles API errors gracefully."""
+    items = [make_item()]
+    client.error_queries.add("Test Artist Test Album")
+
+    albums = metadata.candidates(client, log, items, "Test Artist", "Test Album", False)
+    assert len(albums) == 0

--- a/tests/beetsplug/redacted/test_metadata.py
+++ b/tests/beetsplug/redacted/test_metadata.py
@@ -10,7 +10,7 @@ An example plugin implementation can be found here:
 """
 
 import pytest
-from beets.library import Item
+from beets.library import Item  # type: ignore[import-untyped]
 
 from beetsplug.redacted import metadata
 from beetsplug.redacted.types import RedSearchResponse, RedSearchResult, RedSearchResults
@@ -29,7 +29,6 @@ def client() -> FakeClient:
     return FakeClient()
 
 
-
 def make_item(
     artist: str = "Test Artist",
     album: str = "Test Album",
@@ -37,28 +36,14 @@ def make_item(
     track: int = 1,
 ) -> Item:
     """Create a test Item with album information."""
-    return Item(
-        artist=artist,
-        album=album,
-        title=title,
-        track=track,
-        albumartist=artist,
-    )
+    return Item(artist=artist, album=album, title=title, track=track, albumartist=artist)
 
 
 def make_result(
-    id: int = 1,
-    artist: str = "Test Artist",
-    name: str = "Test Album",
-    year: int = 2020,
+    id: int = 1, artist: str = "Test Artist", name: str = "Test Album", year: int = 2020
 ) -> RedSearchResult:
     """Create a test torrent group."""
-    return RedSearchResult(
-        groupId=id,
-        artist=artist,
-        groupName=name,
-        groupYear=year,
-    )
+    return RedSearchResult(groupId=id, artist=artist, groupName=name, groupYear=year)
 
 
 def test_candidates_no_matches(client: FakeClient, log: FakeLogger) -> None:
@@ -75,21 +60,18 @@ def test_candidates_with_matches(client: FakeClient, log: FakeLogger) -> None:
     group_1 = make_result(artist="Test Artist", name="Test Album", year=2020)
     group_2 = make_result(artist="Test Artist 2", name="Test Album 2")
     client.search_responses["Test Artist Test Album"] = RedSearchResponse(
-        status="success",
-        response=RedSearchResults(results=[group_1, group_2]),
+        status="success", response=RedSearchResults(results=[group_1, group_2])
     )
 
     albums = metadata.candidates(client, log, items, "Test Artist", "Test Album", False)
     assert len(albums) == 2
 
     album = albums[0]
-    assert album.red_groupid == group_1.groupId
     assert album.albumartist == group_1.artist
     assert album.album == group_1.groupName
     assert album.year == group_1.groupYear
 
     album = albums[1]
-    assert album.red_groupid == group_2.groupId
     assert album.albumartist == group_2.artist
     assert album.album == group_2.groupName
     assert album.year == group_2.groupYear
@@ -101,27 +83,22 @@ def test_skips_va_albums(client: FakeClient, log: FakeLogger) -> None:
     albums = metadata.candidates(client, log, [], "Various Artists", "Test Album", va_likely)
     assert len(albums) == 0
 
-def test_candidates_normalizes_query(
-    client: FakeClient,
-    log: FakeLogger
-) -> None:
+
+def test_candidates_normalizes_query(client: FakeClient, log: FakeLogger) -> None:
     """Test that candidates normalizes the search query."""
     items = [make_item(artist="Test Artist (feat. Someone)", album="Test Album [Remastered]")]
     client.search_responses["Test Artist Test Album"] = RedSearchResponse(
-        status="success",
-        response=RedSearchResults(results=[make_result()]),
+        status="success", response=RedSearchResults(results=[make_result()])
     )
 
-    albums = metadata.candidates(client, log, items, "Test Artist (feat. Someone)", "Test Album [Remastered]", False)
+    albums = metadata.candidates(
+        client, log, items, "Test Artist (feat. Someone)", "Test Album [Remastered]", False
+    )
     assert len(albums) == 1
     assert "Test Artist Test Album" in client.queries
 
 
-
-def test_candidates_error_handling(
-    client: FakeClient,
-    log: FakeLogger
-) -> None:
+def test_candidates_error_handling(client: FakeClient, log: FakeLogger) -> None:
     """Test that candidates handles API errors gracefully."""
     items = [make_item()]
     client.error_queries.add("Test Artist Test Album")

--- a/tests/beetsplug/redacted/test_search.py
+++ b/tests/beetsplug/redacted/test_search.py
@@ -24,12 +24,7 @@ from beetsplug.redacted.types import (
     RedSearchResults,
     RedSearchTorrent,
 )
-from beetsplug.redacted.utils.test_utils import (
-    FakeAlbum,
-    FakeLibrary,
-    FakeLogger,
-    FakeClient,
-)
+from beetsplug.redacted.utils.test_utils import FakeAlbum, FakeClient, FakeLibrary, FakeLogger
 
 TEST_ARTIST_ID = 1
 TEST_GROUP_ID = 2
@@ -229,9 +224,7 @@ def _make_test_group(
     )
 
 
-def _setup_search_responses(
-    client: FakeClient, query: str, groups: list[RedSearchResult]
-) -> None:
+def _setup_search_responses(client: FakeClient, query: str, groups: list[RedSearchResult]) -> None:
     """Set up search responses for the client.
 
     Args:
@@ -478,9 +471,7 @@ def test_search_torrents_no_artist_id_in_torrent(
     assert len(client.artist_queries) == 0
 
 
-def test_search_torrents_no_match(
-    log: FakeLogger, client: FakeClient, album: FakeAlbum
-) -> None:
+def test_search_torrents_no_match(log: FakeLogger, client: FakeClient, album: FakeAlbum) -> None:
     """Test searching for torrents with no match."""
     # Set up test response with no matching groups
     _setup_search_responses(client, f"{TEST_ARTIST_NAME} {TEST_ALBUM_NAME}", [])
@@ -490,9 +481,7 @@ def test_search_torrents_no_match(
     assert result is None
 
 
-def test_search_torrents_with_error(
-    log: FakeLogger, client: FakeClient, album: FakeAlbum
-) -> None:
+def test_search_torrents_with_error(log: FakeLogger, client: FakeClient, album: FakeAlbum) -> None:
     """Test searching for torrents with an error."""
     # Set up test response with an error
     client.error_queries.add(f"{TEST_ARTIST_NAME} {TEST_ALBUM_NAME}")

--- a/tests/beetsplug/redacted/test_search.py
+++ b/tests/beetsplug/redacted/test_search.py
@@ -28,7 +28,7 @@ from beetsplug.redacted.utils.test_utils import (
     FakeAlbum,
     FakeLibrary,
     FakeLogger,
-    FakeRedactedClient,
+    FakeClient,
 )
 
 TEST_ARTIST_ID = 1
@@ -47,9 +47,9 @@ def log() -> FakeLogger:
 
 
 @pytest.fixture
-def client() -> FakeRedactedClient:
+def client() -> FakeClient:
     """Create a fake client for testing."""
-    return FakeRedactedClient()
+    return FakeClient()
 
 
 @pytest.fixture
@@ -230,7 +230,7 @@ def _make_test_group(
 
 
 def _setup_search_responses(
-    client: FakeRedactedClient, query: str, groups: list[RedSearchResult]
+    client: FakeClient, query: str, groups: list[RedSearchResult]
 ) -> None:
     """Set up search responses for the client.
 
@@ -245,7 +245,7 @@ def _setup_search_responses(
 
 
 def _setup_artist_response(
-    client: FakeRedactedClient,
+    client: FakeClient,
     artist_id: int = TEST_ARTIST_ID,
     artist_name: str = TEST_ARTIST_NAME,
     torrent_groups: Union[list[RedArtistTorrentGroup], None] = None,
@@ -327,7 +327,7 @@ def test_match_album_exact_match(
 
 def test_search_torrents_with_artist_lookup(
     log: FakeLogger,
-    client: FakeRedactedClient,
+    client: FakeClient,
     album: FakeAlbum,
     test_torrent: RedSearchTorrent,
     test_artist_group: RedArtistTorrentGroup,
@@ -364,7 +364,7 @@ def test_search_torrents_with_artist_lookup(
 
 def test_search_torrents_artist_lookup_better_match(
     log: FakeLogger,
-    client: FakeRedactedClient,
+    client: FakeClient,
     album: FakeAlbum,
     test_torrent: RedSearchTorrent,
     test_artist_torrent: RedArtistTorrent,
@@ -411,7 +411,7 @@ def test_search_torrents_artist_lookup_better_match(
 
 
 def test_search_torrents_artist_lookup_failed(
-    log: FakeLogger, client: FakeRedactedClient, album: FakeAlbum, test_torrent: RedSearchTorrent
+    log: FakeLogger, client: FakeClient, album: FakeAlbum, test_torrent: RedSearchTorrent
 ) -> None:
     """Test handling case where artist lookup fails but we still use initial match."""
     # Set up test response for initial browse search
@@ -442,7 +442,7 @@ def test_search_torrents_artist_lookup_failed(
 
 
 def test_search_torrents_no_artist_id_in_torrent(
-    log: FakeLogger, client: FakeRedactedClient, album: FakeAlbum
+    log: FakeLogger, client: FakeClient, album: FakeAlbum
 ) -> None:
     """Test handling case where torrent has no artist ID for lookup."""
     # Create a torrent with no artist ID
@@ -479,7 +479,7 @@ def test_search_torrents_no_artist_id_in_torrent(
 
 
 def test_search_torrents_no_match(
-    log: FakeLogger, client: FakeRedactedClient, album: FakeAlbum
+    log: FakeLogger, client: FakeClient, album: FakeAlbum
 ) -> None:
     """Test searching for torrents with no match."""
     # Set up test response with no matching groups
@@ -491,7 +491,7 @@ def test_search_torrents_no_match(
 
 
 def test_search_torrents_with_error(
-    log: FakeLogger, client: FakeRedactedClient, album: FakeAlbum
+    log: FakeLogger, client: FakeClient, album: FakeAlbum
 ) -> None:
     """Test searching for torrents with an error."""
     # Set up test response with an error
@@ -504,7 +504,7 @@ def test_search_torrents_with_error(
 
 def test_search_torrents_with_variants(
     log: FakeLogger,
-    client: FakeRedactedClient,
+    client: FakeClient,
     test_torrent: RedSearchTorrent,
     test_artist_group: RedArtistTorrentGroup,
 ) -> None:


### PR DESCRIPTION
To improve album matching, and particularly to improve matching of specific torrents to albums in the user's library, first look up the user's "snatched" torrents and prioritize them when selecting which specific groups and torrents to record in the Beets database.

This adds an optional "user_id" field to the redacted plugin's configuration, and requires that the API key has user scope.

In the process, refactored the search tests to be much more modular by using test parameterization more extensively.